### PR TITLE
chore: update lint-staged configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "husky install",
-    "format": "prettier --cache --write",
+    "format": "prettier --write",
     "format:check": "prettier --check .",
     "lint": "eslint . --fix",
     "lint:check": "eslint ."
@@ -44,9 +44,12 @@
     "prettier": "^3.0.3"
   },
   "lint-staged": {
-    "*.js": [
+    "**/*.js": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --max-warnings=0 --fix"
+    ],
+    "**/*.md": [
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
## what 
lint-staged 설정에서 prettier, eslint 설정 변경

1. `--cache` 삭제 및 lint-staged 설정에 추가 보류
2. 확장자에 따라 명령 구분
3. eslint `--max-warnings` flag 추가


## why

### 1. `--cache` 삭제 및 lint-staged 설정에 추가 보류
https://github.com/typescript-eslint/typescript-eslint/issues/4694
> From experience - in general ESLint caching can be a real problem across the entire ecosystem.
> 
> Unless every single lint rule you use only depends on single-file analysis, you can quickly end up in an inconsistent lint state.
> A few quick examples off the top of my head:
> 
> there are a number of rules in eslint-plugin-import all do their own cross-file analysis (not using TS).
> eslint-plugin-prettier depends on your .prettierrc file.
> At Meta we also have a number of internal lint rules that depend on code loaded from source and also on file locations.
> I also don't know if the cache respects plugin/config/parser versions - so if you checkout master and that has version changes, I don't know if ESLint would correctly blow away the cache automatically.
> 
> In general I would just warn against using the cache, regardless of if you use our tooling or not because you don't really know what external metadata your plugins may or may not depend on and the cache could cause undefined behaviour.
>
>TBH I don't think I've ever even seen the flag turned on in a codebase (eslint themselves don't even use it!).

만약 eslint-typescript를 사용한다면  `--cache` 무용지물
https://github.com/eslint/eslint/discussions/16997
https://groups.google.com/g/eslint/c/ttG76LQ4GFI

### 2. 확장자에 따라 명령 구분

`.md`파일은 eslint를 할 필요가 없다.  
`next.js`에서는 [확장자에 따라 명령을 구분지어 놓았다.](https://github.com/vercel/next.js/blob/canary/lint-staged.config.js)  


### 3. eslint `--max-warnings` flag 추가
 
[ what is `--max-warnings`?]( https://eslint.org/docs/latest/use/command-line-interface#--max-warnings)
https://github.com/eslint/eslint/issues/2769
나쁜 코드가 추가되는 것을 방지하기 위해서
